### PR TITLE
Fix typo in time period hash

### DIFF
--- a/PowerLFM/Private/ConvertTo-LFMParameter.ps1
+++ b/PowerLFM/Private/ConvertTo-LFMParameter.ps1
@@ -28,7 +28,7 @@ function ConvertTo-LFMParameter {
 
     $period = @{
         'Overall' = 'overall'
-        '7 Days' = '7days'
+        '7 Days' = '7day'
         '1 Month' = '1month'
         '3 Months' = '3month'
         '6 Months' = '6month'


### PR DESCRIPTION
Fixes #99 

There was a typo in the property name for the '7 Days' parameter in the Get-UserTop* functions.