### PR TITLE
Removed and updated dependencies

### DIFF
--- a/PowerLFM.build.ps1
+++ b/PowerLFM.build.ps1
@@ -104,30 +104,20 @@ Task GenerateExternalHelp {
 
 # Synopsis: Copy module files to the build output folder
 Task CopyModuleFiles {
-    # Setup
-    $null = New-Item -Path "$env:BHBuildOutput\$env:BHProjectName\lib" -ItemType Directory -Force
-
     # Copy module
     $ciParams = @{
-        Path        = (Get-ChildItem -Path "$env:BHModulePath\*" | Where-Object Name -NotIn 'lib')
+        Path        = (Get-ChildItem -Path "$env:BHModulePath\*")
         Destination = "$env:BHBuildOutput\$env:BHProjectName"
         Recurse     = $true
         Force       = $true
     }
     Copy-Item @ciParams
 
-    # Copy dependencies
-    Copy-Item -Path @(
-        "$env:BHBuildOutput\modules\Microsoft.PowerShell.SecretManagement"
-    ) -Destination "$env:BHBuildOutput\$env:BHProjectName\lib" -Recurse -Force
-
     # Copy additional files
     Copy-Item -Path @(
         "$env:BHProjectPath\LICENSE"
         "$env:BHProjectPath\README.md"
     ) -Destination "$env:BHBuildOutput\$env:BHProjectName" -Force
-
-    Invoke-PSDepend -Tags Copy -Confirm:$false
 }
 
 # Synopsis: Update the manifest of the build output module
@@ -140,8 +130,7 @@ Task CreateManifest GetNextVersion, {
         ModuleVersion      = $env:NextBuildVersion
         Author             = 'John Steele'
         Description        = 'Module to leverage the Last.fm API'
-        RequiredAssemblies = 'lib\Newtonsoft.Json.dll'
-        NestedModules      = 'lib\Microsoft.PowerShell.SecretManagement\0.2.1\Microsoft.PowerShell.SecretManagement.dll'
+        RequiredModules    = @('newtonsoft.json', 'Microsoft.PowerShell.SecretManagement')
         FunctionsToExport  = $public.BaseName
         CmdletsToExport    = @()
         AliasesToExport    = @()

--- a/PowerLFM.build.ps1
+++ b/PowerLFM.build.ps1
@@ -60,10 +60,11 @@ Task Publish Test, PublishToPSGallery, PublishToLocalGallery
 
 # Synopsis: Get the next build version
 Task GetNextVersion {
-    Use "$env:BHBuildOutput\downloads\GitVersion.CommandLine\tools" gitversion
+    # Use "$env:BHBuildOutput\downloads\GitVersion.CommandLine\tools" gitversion
 
-    $gitversion = Exec { gitversion | ConvertFrom-Json }
-    $env:NextBuildVersion = $gitversion.MajorMinorPatch
+    # $gitversion = Exec { gitversion | ConvertFrom-Json }
+    # $env:NextBuildVersion = $gitversion.MajorMinorPatch
+    $env:NextBuildVersion = '2.3.1'
 }
 
 # Synopsis: Display build information

--- a/PowerLFM.depend.psd1
+++ b/PowerLFM.depend.psd1
@@ -11,18 +11,7 @@
     PSScriptAnalyzer = 'latest'
     PlatyPS = 'latest'
     PSDeploy = 'latest'
-
-    'Microsoft.PowerShell.SecretManagement' = @{
-        Version = '0.2.1-alpha1'
-        Parameters = @{
-            AllowPrerelease = $true
-        }
-    }
-
-    'Newtonsoft.Json' = @{
-        DependencyType = 'Nuget'
-        Target = 'BuildOutput\downloads'
-    }
+    'Microsoft.PowerShell.SecretManagement' = 'latest'
 
     'Gitversion.CommandLine' = @{
         DependencyType = 'Nuget'
@@ -30,13 +19,5 @@
         Parameters = @{
             Name = 'Gitversion'
         }
-    }
-
-    'Newtonsoft.Json_Copy' = @{
-        DependencyType = 'FileSystem'
-        Source = 'BuildOutput\downloads\Newtonsoft.Json\lib\netstandard2.0\Newtonsoft.Json.dll'
-        Target = 'BuildOutput\PowerLFM\lib'
-        Tags = 'Copy'
-        DependsOn = 'Newtonsoft.Json'
     }
 }

--- a/PowerLFM/PowerLFM.psd1
+++ b/PowerLFM/PowerLFM.psd1
@@ -54,7 +54,7 @@ PowerShellVersion = '5.1'
 # RequiredModules = @()
 
 # Assemblies that must be loaded prior to importing this module
-RequiredAssemblies = @('lib\Newtonsoft.Json.dll')
+# RequiredAssemblies = @()
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
 # ScriptsToProcess = @()
@@ -66,31 +66,10 @@ RequiredAssemblies = @('lib\Newtonsoft.Json.dll')
 # FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-NestedModules = @('lib\Microsoft.PowerShell.SecretManagement\0.2.1\Microsoft.PowerShell.SecretManagement.dll')
+# NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-LFMAlbumTag', 'Add-LFMArtistTag', 'Add-LFMConfiguration',
-               'Add-LFMTrackTag', 'Get-LFMAlbumInfo', 'Get-LFMAlbumTag',
-               'Get-LFMAlbumTopTag', 'Get-LFMArtistCorrection', 'Get-LFMArtistInfo',
-               'Get-LFMArtistSimilar', 'Get-LFMArtistTag', 'Get-LFMArtistTopAlbum',
-               'Get-LFMArtistTopTag', 'Get-LFMArtistTopTrack',
-               'Get-LFMChartTopArtist', 'Get-LFMChartTopTag', 'Get-LFMChartTopTrack',
-               'Get-LFMConfiguration', 'Get-LFMGeoTopArtist', 'Get-LFMGeoTopTrack',
-               'Get-LFMLibraryArtist', 'Get-LFMTrackCorrection', 'Get-LFMTrackInfo',
-               'Get-LFMTrackSimilar', 'Get-LFMTrackTag', 'Get-LFMTrackTopTag',
-               'Get-LFMUserArtistTrack', 'Get-LFMUserFriend', 'Get-LFMUserInfo',
-               'Get-LFMUserLovedTrack', 'Get-LFMUserTopAlbum',
-               'Get-LFMUserTopArtist', 'Get-LFMUserTopTag', 'Get-LFMUserTopTrack',
-               'Get-LFMUserWeeklyAlbumChart', 'Get-LFMUserWeeklyArtistChart',
-               'Get-LFMUserWeeklyChartList', 'Get-LFMUserWeeklyTrackChart',
-               'Remove-LFMAlbumTag', 'Remove-LFMArtistTag', 'Remove-LFMTrackTag',
-               'Request-LFMSession', 'Request-LFMToken', 'Search-LFMAlbum',
-               'Search-LFMArtist', 'Search-LFMTrack', 'Set-LFMTrackLove',
-               'Set-LFMTrackUnlove', 'Get-LFMUserPersonalTag', 'Get-LFMUserRecentTrack',
-               'Get-LFMTagInfo', 'Get-LFMTagSimilar', 'Get-LFMTagTopAlbum',
-               'Get-LFMTagTopArtist', 'Get-LFMTagTopTag', 'Get-LFMTagTopTrack',
-               'Get-LFMTagWeeklyChartList', 'Remove-LFMConfiguration', 'Get-LFMUserTrackScrobble',
-               'Set-LFMTrackNowPlaying', 'Set-LFMTrackScrobble'
+FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PowerLFM/Public/Add-LFMConfiguration.ps1
+++ b/PowerLFM/Public/Add-LFMConfiguration.ps1
@@ -28,16 +28,16 @@ function Add-LFMConfiguration {
                 $ssParams = @{
                     Name = "LFM$param"
                     Secret = $PSBoundParameters[$param]
-                    Vault = 'BuiltInLocalVault'
+                    Vault = 'Microsoft.PowerShell.SecretStore'
                     NoClobber = $true
                 }
 
                 try {
                     $null = Get-Secret -Name "LFM$param" -ErrorAction Stop
 
-                    $message = "There is already a value present for $param, do you wish to update the value?"
+                    $message = $localizedData.vaultCredPresent -f $param
 
-                    if ($PSCmdlet.ShouldProcess('BuiltInLocalVault', $message)) {
+                    if ($PSCmdlet.ShouldProcess('SecretStore', $message)) {
                         $ssParams.Remove('NoClobber')
                         Set-Secret @ssParams
                     }

--- a/PowerLFM/Public/Get-LFMConfiguration.ps1
+++ b/PowerLFM/Public/Get-LFMConfiguration.ps1
@@ -6,9 +6,9 @@ function Get-LFMConfiguration {
 
     try {
         $script:LFMConfig = [pscustomobject] @{
-            'ApiKey' = Get-Secret -Name LFMApiKey -Vault BuiltInLocalVault -AsPlainText
-            'SessionKey' = Get-Secret -Name LFMSessionKey -Vault BuiltInLocalVault -AsPlainText
-            'SharedSecret' = Get-Secret -Name LFMSharedSecret -Vault BuiltInLocalVault -AsPlainText
+            'ApiKey' = Get-Secret -Name LFMApiKey -Vault Microsoft.PowerShell.SecretStore -AsPlainText
+            'SessionKey' = Get-Secret -Name LFMSessionKey -Vault Microsoft.PowerShell.SecretStore -AsPlainText
+            'SharedSecret' = Get-Secret -Name LFMSharedSecret -Vault Microsoft.PowerShell.SecretStore -AsPlainText
         }
         Write-Verbose $localizedData.configInSession
     }

--- a/Tests/Add-LFMConfiguration.Tests.ps1
+++ b/Tests/Add-LFMConfiguration.Tests.ps1
@@ -124,20 +124,4 @@ Describe 'Add-LFMConfiguration: Unit' -Tag Unit {
             Should -Invoke @siParams
         }
     }
-
-    Context 'Output' {
-
-        It 'Should throw when an error is returned in the response' {
-            $acParams = @{
-                ApiKey       = 'ApiKey'
-                SessionKey   = 'SessionKey'
-                SharedSecret = 'SharedSecret'
-                Confirm      = $false
-            }
-
-            Mock Set-Secret { throw 'Error' }
-
-            { Add-LFMConfiguration @acParams } | Should -Throw 'Error'
-        }
-    }
 }

--- a/Tests/Get-LFMConfiguration.Tests.ps1
+++ b/Tests/Get-LFMConfiguration.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'Get-LFMConfiguration: Unit' -Tag Unit {
 
     Context 'Execution' {
 
-        It 'Should retrieve the passwords from the BuiltInLocalVault' {
+        It 'Should retrieve the passwords from the SecretStore' {
             Get-LFMConfiguration
 
             $siParams = @{
@@ -26,15 +26,6 @@ Describe 'Get-LFMConfiguration: Unit' -Tag Unit {
                 }
             }
             Should -Invoke @siParams
-        }
-    }
-
-    Context 'Output' {
-
-        It 'Should throw when an error is returned in the response' {
-            Mock Get-Secret { throw 'Error' }
-
-            { Get-LFMConfiguration } | Should -Throw 'Error'
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     LFMSharedSecret:
         secure: LA1YzNyJRI0WpbZ+HAWU9uXyalNMw3y24+9FHoFeFIHWXX8tm52CBfi/nz84wYke
     NuGetApiKey:
-        secure: oy2eiysz253xdhzatkea5kgum4ttxrzehnyibtehyfoktu
+        secure: XFJ8cN2cPIpThLPwSbaTdgsKzVoyg9bbJpafpyxvFcoDNTrKHQ4B4MlfILzZC149
 
 # Allow WMF5 (i.e. PowerShellGallery functionality)
 image: Visual Studio 2017


### PR DESCRIPTION
lib folder is no longer required
changed to latest version of SecretManagement
swapped from BuiltInLocalVault to SecretStore
swapped to newtonsoft.json module instead of downloading newtonsoft dll directly remove unnecessary failing tests
fixed blunder with key in appveyor