### PR TITLE
Fix bugs and code quality issues from code review

### DIFF
--- a/source/Public/Add-LFMAlbumTag.ps1
+++ b/source/Public/Add-LFMAlbumTag.ps1
@@ -35,8 +35,7 @@ function Add-LFMAlbumTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Album: $Album", "Adding album tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Add-LFMArtistTag.ps1
+++ b/source/Public/Add-LFMArtistTag.ps1
@@ -29,8 +29,7 @@ function Add-LFMArtistTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Artist: $Artist", "Adding artist tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Add-LFMTrackTag.ps1
+++ b/source/Public/Add-LFMTrackTag.ps1
@@ -35,8 +35,7 @@ function Add-LFMTrackTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Adding track tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Remove-LFMAlbumTag.ps1
+++ b/source/Public/Remove-LFMAlbumTag.ps1
@@ -35,8 +35,7 @@ function Remove-LFMAlbumTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Album: $Album", "Removing album tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Remove-LFMArtistTag.ps1
+++ b/source/Public/Remove-LFMArtistTag.ps1
@@ -30,8 +30,7 @@ function Remove-LFMArtistTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Artist: $Artist", "Removing artist tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Remove-LFMTrackTag.ps1
+++ b/source/Public/Remove-LFMTrackTag.ps1
@@ -35,8 +35,7 @@ function Remove-LFMTrackTag {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Removing track tag: $Tag")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Set-LFMTrackLove.ps1
+++ b/source/Public/Set-LFMTrackLove.ps1
@@ -30,8 +30,7 @@ function Set-LFMTrackLove {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Adding love")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Set-LFMTrackNowPlaying.ps1
+++ b/source/Public/Set-LFMTrackNowPlaying.ps1
@@ -47,8 +47,7 @@ function Set-LFMTrackNowPlaying {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Setting track to now playing")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Set-LFMTrackScrobble.ps1
+++ b/source/Public/Set-LFMTrackScrobble.ps1
@@ -56,8 +56,7 @@ function Set-LFMTrackScrobble {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Setting track to now playing")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post

--- a/source/Public/Set-LFMTrackUnlove.ps1
+++ b/source/Public/Set-LFMTrackUnlove.ps1
@@ -30,8 +30,7 @@ function Set-LFMTrackUnlove {
         $convertedParams = ConvertTo-LFMParameter $noCommonParams
         $query = New-LFMApiQuery ($convertedParams + $apiParams)
         $apiUrl = "$baseUrl/?$query"
-    }
-    end {
+
         if ($PSCmdlet.ShouldProcess("Track: $Track", "Removing love")) {
             try {
                 $irm = Invoke-LFMApiUri -Uri $apiUrl -Method Post


### PR DESCRIPTION
## Summary

- **Pipeline fix**: Move `ShouldProcess` + `Invoke-LFMApiUri` from `end` to `process` block in all 10 mutation functions (`Add-*`, `Remove-*`, `Set-*`) so each piped object gets its own API request
- **Bug fixes**: Out-of-scope variables in `ConvertTo-LFMParameter`, wrong vault name in `Remove-LFMConfiguration`, wrong API method casing in `Get-LFMUserInfo`, `OnTour`/`Loved` switch integer mismatch, call stack key typo (`Username` → `UserName`)
- **Code quality**: URL encoding in `New-LFMApiQuery`, `MD5CryptoServiceProvider` disposal, null guard in `Invoke-LFMApiUri`, missing `.ExternalHelp` in `Get-LFMUserRecentTrack`, `ConvertTo-TitleCase` array handling

## New tests

- `ConvertTo-LFMParameter.tests.ps1` — key mapping, date conversions, `TimePeriod` translation, internal key removal
- `New-LFMApiQuery.tests.ps1` — query building, URL encoding of special characters, signature mode
- `ConvertTo-TitleCase.tests.ps1` — single string, array input (with `Should -BeExactly` for case-sensitive assertions)
- Pipeline tests in `Add-LFMAlbumTag` and `Set-LFMTrackLove` — verify no throw and correct call count per piped object
- `OnTour` output test in `Get-LFMArtistInfo` — integer `1` maps to `'Yes'`
- Vault name assertions in `Remove-LFMConfiguration` — verifies `Microsoft.PowerShell.SecretStore` is used

## Test plan

- [ ] Run Pester tests: `Invoke-Pester ./source/tests`
- [ ] Verify pipeline behaviour: pipe 2+ objects into `Add-LFMAlbumTag`, `Set-LFMTrackLove`, etc. and confirm each gets an API call
- [ ] Verify `Remove-LFMConfiguration` targets the correct vault